### PR TITLE
#12 - AuditingFields 추출

### DIFF
--- a/src/main/java/com/fastboard/fastboardproject/domain/Article.java
+++ b/src/main/java/com/fastboard/fastboardproject/domain/Article.java
@@ -25,7 +25,7 @@ import java.util.Set;
 })
 @EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Article {
+public class Article extends AuditingFields{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,20 +47,6 @@ public class Article {
     @ToString.Exclude
     private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
 
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @CreatedBy
-    @Column(nullable = false, length = 100)
-    String createdBy;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;
-
-    @LastModifiedBy
-    @Column(nullable = false, length = 100)
-    private String modifiedBy;
 
 
     protected Article() {

--- a/src/main/java/com/fastboard/fastboardproject/domain/ArticleComment.java
+++ b/src/main/java/com/fastboard/fastboardproject/domain/ArticleComment.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 
 @EntityListeners(AuditingEntityListener.class)
 @Entity
-public class ArticleComment {
+public class ArticleComment extends AuditingFields{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -35,21 +35,6 @@ public class ArticleComment {
     @Setter
     @Column(nullable = false, length = 500)
     private String content;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @CreatedBy
-    @Column(nullable = false, length = 100)
-    private String createdBy;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;
-
-    @LastModifiedBy
-    @Column(nullable = false, length = 100)
-    private String modifiedBy;
 
     protected ArticleComment() {
     }

--- a/src/main/java/com/fastboard/fastboardproject/domain/AuditingFields.java
+++ b/src/main/java/com/fastboard/fastboardproject/domain/AuditingFields.java
@@ -1,0 +1,40 @@
+package com.fastboard.fastboardproject.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@ToString
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(nullable = false, length = 100, updatable = false)
+    String createdBy;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    private String modifiedBy;
+}


### PR DESCRIPTION
생성자, 생성일시, 수정자,수정일시는 
반복적으로 엔티티클래스에 들어가는 요소이고
도메인과 직접 연관이 없는 요소이므로 추출이 가능하다
@MappedSuperClass를 이용해 상속
@DateFormat 요소 추가